### PR TITLE
Fix a bug with i18n modal navigation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 
 script:
   - real-favicon generate _assets/img/faviconDescription.json /dev/null .
-  - JEKYLL_ENV=production bundle exec jekyll build --future
+  - JEKYLL_ENV=production bundle exec jekyll build
 
   - bundle exec yaml-lint _i18n/*.yml .travis.yml _config.yml .scss-lint.yml _data/sponsors.yml docker-compose.yml
   - bundle exec htmlproofer --allow-hash-href --disable-external --check-html  _site

--- a/_assets/js/main.coffee
+++ b/_assets/js/main.coffee
@@ -124,14 +124,14 @@ window.initMap = ->
 # Open a modal window with the set modal's content loaded
 # url should be in the form workshops/do-it-yourself.html (no leading # or /)
 showModal = (url) ->
-  # Forcing the prepending of .href helps mitigrate some XSS attacks
+  # Forcing the prepending of .href helps mitigate some XSS attacks
   url = "#{getPageUrl()}#{url}.html"
   $('#modal-details').find('.modal-content').html('').load(url)
   $('#modal-details').modal 'show'
 
 # Return the URL of the current page, without the .hash part
 getPageUrl = ->
-  window.location.href.substr 0, window.location.href.indexOf('#')-1
+  window.location.href.substr 0, window.location.href.indexOf('#')
 
 $ ->
 
@@ -153,7 +153,7 @@ $ ->
 
     # Fix bug for language'd pages where the URL contains "double" language
     # Example: https://improfestival.ee/en#/en/workshops
-    url = url.replace('/en', '')
+    url = url.replace '/en/', ''
 
     # Append the modal's ID to the URL's hash
     window.location.hash = url.replace('.html', '')


### PR DESCRIPTION
When viewing a non-default language page (/en/) and opening a modal link (performance details) more than once, the URL displayed on the URL bar would start to truncate, one letter at a time (per open/close). 

This would cause incorrect navigation when opening/closing modals (viewing default language content while on a language page).

Closes #39